### PR TITLE
Feat/reload widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# MacOS trash
+.DS_Store

--- a/Bonera_Preferences/Preferences.py
+++ b/Bonera_Preferences/Preferences.py
@@ -324,6 +324,7 @@ class BONERA_user_preferences(bpy.types.AddonPreferences):
         layout.label(text="Bone Shapes", icon="BONE_DATA")
         row = layout.row(align=True)
         row.operator("bonera.open_bone_shape_folder", text="Open Bone Shape Folder", icon="FILE_FOLDER")
+        row.operator("bonera.reload_widget_categories", text="Reload widgets", icon="FILE_REFRESH")
 
     def draw(self, context):
         layout = self.layout

--- a/Bonera_Preferences/Preferences.py
+++ b/Bonera_Preferences/Preferences.py
@@ -324,7 +324,7 @@ class BONERA_user_preferences(bpy.types.AddonPreferences):
         layout.label(text="Bone Shapes", icon="BONE_DATA")
         row = layout.row(align=True)
         row.operator("bonera.open_bone_shape_folder", text="Open Bone Shape Folder", icon="FILE_FOLDER")
-        row.operator("bonera.reload_widget_categories", text="Reload widgets", icon="FILE_REFRESH")
+        row.operator("bonera.reload_bone_shapes", text="Reload bone shapes", icon="FILE_REFRESH")
 
     def draw(self, context):
         layout = self.layout

--- a/Bonera_Toolkit_Operators/Add_Bone_Shape.py
+++ b/Bonera_Toolkit_Operators/Add_Bone_Shape.py
@@ -64,8 +64,12 @@ def ENUM_Widgets(self, context):
 
 ENUM_Position = [("CURSOR","Cursor","Cursor"),("CENTER","Center","Center")]
 
-Widget_Catagories = Utility_Functions.get_bone_shape_catagories()
+Widget_Catagories = None
 
+def reload_widget_categories():
+    global Widget_Catagories
+
+    Widget_Catagories = Utility_Functions.get_bone_shape_catagories()
 
 def ENUM_Bone_Shape_Catagory(self, context):
 
@@ -110,6 +114,20 @@ def reset_property(self, context):
         self.rotate = (0, 0, 0)
         self.scale = (1, 1, 1)
         self.reset_transform = False
+
+
+class BONERA_Reload_Widget_Categories(bpy.types.Operator):
+    """Operator to reload widget categories"""
+    bl_idname = "bonera.reload_widget_categories"
+    bl_label = "Reload Widget Categories"
+
+    def execute(self, context):
+        # Call the function to reload widget categories
+        reload_widget_categories()
+
+        self.report({'INFO'}, "Widget categories reloaded successfully")
+
+        return {'FINISHED'}
 
 # class BONAD_Add_Bone_Shapes(bpy.types.Operator):
 class BONERA_Add_Bone_Shapes(bpy.types.Operator):
@@ -156,7 +174,7 @@ class BONERA_Add_Bone_Shapes(bpy.types.Operator):
         layout = self.layout
         if context.mode == "OBJECT":
             layout.prop(self, "name", text="Name")
-        layout.prop(self, "bone_shape_catagory", text="Catagory")
+        layout.prop(self, "bone_shape_catagory", text="Category")
         layout.template_icon_view(self, "bone_shape_file", show_labels=False, scale=4.0, scale_popup = 4.0)
 
         if context.mode == "OBJECT":
@@ -254,11 +272,11 @@ class BONERA_Add_Bone_Shapes(bpy.types.Operator):
         return {'FINISHED'}
 
 
-classes = [BONERA_Add_Bone_Shapes]
+classes = [BONERA_Add_Bone_Shapes, BONERA_Reload_Widget_Categories]
 
 def register():
 
-
+    reload_widget_categories()
 
     for cls in classes:
         bpy.utils.register_class(cls)

--- a/Bonera_Toolkit_Operators/Add_Bone_Shape.py
+++ b/Bonera_Toolkit_Operators/Add_Bone_Shape.py
@@ -118,14 +118,14 @@ def reset_property(self, context):
 
 class BONERA_Reload_Widget_Categories(bpy.types.Operator):
     """Operator to reload widget categories"""
-    bl_idname = "bonera.reload_widget_categories"
-    bl_label = "Reload Widget Categories"
+    bl_idname = "bonera.reload_bone_shapes"
+    bl_label = "Reload Bone Shapes"
 
     def execute(self, context):
         # Call the function to reload widget categories
         reload_widget_categories()
 
-        self.report({'INFO'}, "Widget categories reloaded successfully")
+        self.report({'INFO'}, "Bone shapes reloaded successfully")
 
         return {'FINISHED'}
 

--- a/Utility_Operator/Add_Selected_Objects_To_Bone_Shape_Library.py
+++ b/Utility_Operator/Add_Selected_Objects_To_Bone_Shape_Library.py
@@ -67,7 +67,7 @@ class BONERA_Add_Selected_Objects_To_Bone_Shape_Library(bpy.types.Operator):
         layout = self.layout
         layout.label(text="Make Sure to Save Your File First", icon="INFO")
         layout.label(text="Backup this File before Proceeding", icon="INFO")
-        layout.prop(self, "Catagory")
+        layout.prop(self, "Category")
 
 
     def execute(self, context):


### PR DESCRIPTION
Fixes #7 and a typo

I don't understand what `ENUM_Widgets` or `widgets_lists` do. I think they're unused? I wasn't sure, so I left it the way it is. I haven't done that much blender addon dev before, so maybe it's a magic thing, but it looks like copy paste to me.

In any case, this PR is tested and works. Also made sure the initial list is loaded properly (not just when running the operator from preferences).

I chose preferences because it's not common enough to take up space in the main menus of the addon.

![image](https://github.com/BlenderBoi/Bonera/assets/781745/619dbf1e-5800-44c5-abe4-89713973e7ed)
